### PR TITLE
Remove comments for parameterless constructor in ValueListPool<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Differences:
   * Allocation-free
   * Can be created using stackalloc or an array as initial buffer
   * **Cannot be serialized/deserialized**
-  * **Cannot be created with parameterless constructors**, otherwise it is created in an invalid state
   * Because it is ValueType when it is passed to other methods, it is passed by copy, not by reference. In case it is required to be updated, it is required to use the "ref" modifier in the parameter.
     
     

--- a/src/ListPool/ListPool.csproj
+++ b/src/ListPool/ListPool.csproj
@@ -12,7 +12,8 @@
       ListPool and ValueListPool are optimized allocation free implementations of IList using ArrayPool.
 
       Changelog:
-      * Support for netstandard2_0
+      * Performance enhancement in the method AddRange(T[] items) for ListPool and ValueListPool
+      * ValueListPool now can be created with parameterless constructor 
 
       ListPool is the general use of the implementation, we recommend to use ListPool for most of the cases. ValueListPool is the zero heap allocations implementation, it is optimal working along stackalloc initial buffer for small lists. Note, because it is a struct it is passed by value, not by reference.
     </Description>
@@ -20,10 +21,11 @@
     <RepositoryUrl>https://github.com/faustodavid/ListPool</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageVersion>2.3.2</PackageVersion>
+    <PackageVersion>2.3.3-beta</PackageVersion>
     <PackageReleaseNotes>
       Changelog:
-      * Multitarget frameworks to support netstandard2_0.
+      * Performance enhancement in the method AddRange(T[] items) for ListPool and ValueListPool
+      * ValueListPool now can be created with parameterless constructor 
     </PackageReleaseNotes>
     <Copyright>Copyright © Fausto David Suarez Rosario 2020</Copyright>
   </PropertyGroup>

--- a/src/ListPool/ValueListPool.cs
+++ b/src/ListPool/ValueListPool.cs
@@ -7,8 +7,6 @@ namespace ListPool
 {
     /// <summary>
     ///     High-performance implementation of IList with zero heap allocations.
-    ///     IMPORTANT:Do not create ValueListPool without indicating a constructor.
-    ///     Otherwise it wont work.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public ref struct ValueListPool<T> where T : IEquatable<T>
@@ -25,7 +23,7 @@ namespace ListPool
         private Span<T> _buffer;
 
         /// <summary>
-        ///     Construct ListPool with the indicated capacity.
+        ///     Construct ValueListPool with the indicated capacity.
         /// </summary>
         /// <param name="capacity">Required initial capacity</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -37,7 +35,7 @@ namespace ListPool
         }
 
         /// <summary>
-        ///     Construct the ListPool using the giving source.
+        ///     Construct the ValueListPool using the giving source.
         ///     It can use the source as initial buffer in order to reuse the array or
         ///     use the data and wrapper it inside the ListPool or copy the data into new pooled array.
         /// </summary>


### PR DESCRIPTION
This PR is regarding the issue #56 