### PR TITLE
Release 2.3.3

### DIFF
--- a/src/ListPool/ListPool.csproj
+++ b/src/ListPool/ListPool.csproj
@@ -21,7 +21,7 @@
     <RepositoryUrl>https://github.com/faustodavid/ListPool</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageVersion>2.3.3-beta</PackageVersion>
+    <PackageVersion>2.3.3</PackageVersion>
     <PackageReleaseNotes>
       Changelog:
       * Performance enhancement in the method AddRange(T[] items) for ListPool and ValueListPool

--- a/tests/ListPool.Netstandard2_0.UnitTests/ValueListPool/ValueListPoolTests.cs
+++ b/tests/ListPool.Netstandard2_0.UnitTests/ValueListPool/ValueListPoolTests.cs
@@ -469,7 +469,6 @@ namespace ListPool.Netstandard2_0.UnitTests.ValueListPool
             }
         }
 
-
         [Fact]
         public void AddRange_from_array_adds_all_items_as_reference_pool()
         {

--- a/tests/ListPool.Netstandard2_0.UnitTests/ValueListPool/ValueListPoolTests.cs
+++ b/tests/ListPool.Netstandard2_0.UnitTests/ValueListPool/ValueListPoolTests.cs
@@ -8,6 +8,25 @@ namespace ListPool.Netstandard2_0.UnitTests.ValueListPool
 {
     public class ValueListPoolTests : ListPoolTestsBase
     {
+        [Fact]
+        public void Add_items_when_ValueListPool_is_created_without_parameters()
+        {
+            int expectedValueAt0 = s_fixture.Create<int>();
+            int expectedValueAt1 = s_fixture.Create<int>();
+            int expectedValueAt2 = s_fixture.Create<int>();
+            using ValueListPool<int> sut = new ValueListPool<int>();
+
+            sut.Add(expectedValueAt0);
+            sut.Add(expectedValueAt1);
+            sut.Add(expectedValueAt2);
+
+            Assert.Equal(3, sut.Count);
+            Assert.Equal(expectedValueAt0, sut[0]);
+            Assert.Equal(expectedValueAt1, sut[1]);
+            Assert.Equal(expectedValueAt2, sut[2]);
+            
+        }
+
         public override void Add_items_when_capacity_is_full_then_buffer_autogrow()
         {
             using var sut = new ValueListPool<int>(128);
@@ -433,6 +452,23 @@ namespace ListPool.Netstandard2_0.UnitTests.ValueListPool
 
             Assert.True(indexOutOfRangeExceptionThrown);
         }
+
+        [Fact]
+        public void AddRange_from_span_when_ValueListPool_is_created_without_parameters()
+        {
+            ReadOnlySpan<int> expectedValues = new[] {s_fixture.Create<int>(), s_fixture.Create<int>(), s_fixture.Create<int>()};
+            using var sut = new ValueListPool<int>();
+            
+            sut.AddRange(expectedValues);
+
+            Assert.Equal(expectedValues.Length, sut.Count);
+
+            foreach (int expectedValue in expectedValues)
+            {
+                Assert.True(sut.Contains(expectedValue));
+            }
+        }
+
 
         [Fact]
         public void AddRange_from_array_adds_all_items_as_reference_pool()

--- a/tests/ListPool.UnitTests/ValueListPool/ValueListPoolTests.cs
+++ b/tests/ListPool.UnitTests/ValueListPool/ValueListPoolTests.cs
@@ -396,7 +396,6 @@ namespace ListPool.UnitTests.ValueListPool
             Assert.True(indexOutOfRangeExceptionThrown);
         }
 
-
         public override void Set_at_existing_index_update_item()
         {
             const int expectedItemsCount = 3;

--- a/tests/ListPool.UnitTests/ValueListPool/ValueListPoolTests.cs
+++ b/tests/ListPool.UnitTests/ValueListPool/ValueListPoolTests.cs
@@ -8,6 +8,25 @@ namespace ListPool.UnitTests.ValueListPool
 {
     public class ValueListPoolTests : ListPoolTestsBase
     {
+        [Fact]
+        public void Add_items_when_ValueListPool_is_created_without_parameters()
+        {
+            int expectedValueAt0 = s_fixture.Create<int>();
+            int expectedValueAt1 = s_fixture.Create<int>();
+            int expectedValueAt2 = s_fixture.Create<int>();
+            using ValueListPool<int> sut = new ValueListPool<int>();
+
+            sut.Add(expectedValueAt0);
+            sut.Add(expectedValueAt1);
+            sut.Add(expectedValueAt2);
+
+            Assert.Equal(3, sut.Count);
+            Assert.Equal(expectedValueAt0, sut[0]);
+            Assert.Equal(expectedValueAt1, sut[1]);
+            Assert.Equal(expectedValueAt2, sut[2]);
+            
+        }
+
         public override void Add_items_when_capacity_is_full_then_buffer_autogrow()
         {
             using var sut = new ValueListPool<int>(128);
@@ -433,6 +452,23 @@ namespace ListPool.UnitTests.ValueListPool
 
             Assert.True(indexOutOfRangeExceptionThrown);
         }
+
+        [Fact]
+        public void AddRange_from_span_when_ValueListPool_is_created_without_parameters()
+        {
+            ReadOnlySpan<int> expectedValues = new[] {s_fixture.Create<int>(), s_fixture.Create<int>(), s_fixture.Create<int>()};
+            using var sut = new ValueListPool<int>();
+            
+            sut.AddRange(expectedValues);
+
+            Assert.Equal(expectedValues.Length, sut.Count);
+
+            foreach (int expectedValue in expectedValues)
+            {
+                Assert.True(sut.Contains(expectedValue));
+            }
+        }
+
 
         [Fact]
         public void AddRange_from_array_adds_all_items_as_reference_pool()


### PR DESCRIPTION
 Changelog:
      * Performance enhancement in the method AddRange(T[] items) for ListPool and ValueListPool
      * ValueListPool now can be created with parameterless constructor 