### PR TITLE
update setup-dotnet to 1.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.0.0
+      uses: actions/setup-dotnet@v1.4.0
       with:
         version: 3.1.100
 
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v1.0.0
+      uses: actions/setup-dotnet@v1.4.0
       with:
         version: 3.1.100
 


### PR DESCRIPTION
GitHub action pipeline is failing because of a bug in the setup-dotnet step. It looks like it is fixed in version 1.4.0.

https://github.com/microsoft/azure-pipelines-tasks/issues/10968